### PR TITLE
feat: add NovaOpenAI tool registration in NovaServiceProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ php artisan migrate
 php artisan vendor:publish --tag=nova-openai-config
 ```
 
+Register the tool with Nova in the `tools()` method of the `NovaServiceProvider`:
+
+```php
+// in app/Providers/NovaServiceProvider.php
+
+public function tools()
+{
+    return [
+        \Outl1ne\NovaOpenAI\NovaOpenAI::make(),
+    ];
+}
+```
+
 ## Usage
 
 ```php


### PR DESCRIPTION
The `NovaOpenAI` tool is now registered in the `tools()` method of the `NovaServiceProvider` to make it available in the Nova dashboard.