### PR TITLE
fix: errors with missing headers

### DIFF
--- a/src/Capabilities/Chat/Responses/ChatResponse.php
+++ b/src/Capabilities/Chat/Responses/ChatResponse.php
@@ -34,12 +34,12 @@ class ChatResponse
             totalTokens: $data['usage']['total_tokens'],
         );
         $this->rateLimit = new RateLimit(
-            limitRequests: $headers['x-ratelimit-limit-requests'][0],
-            limitTokens: $headers['x-ratelimit-limit-tokens'][0],
-            remainingRequests: $headers['x-ratelimit-remaining-requests'][0],
-            remainingTokens: $headers['x-ratelimit-remaining-tokens'][0],
-            resetRequests: $headers['x-ratelimit-reset-requests'][0],
-            resetTokens: $headers['x-ratelimit-reset-tokens'][0],
+            limitRequests: $headers['x-ratelimit-limit-requests'][0] ?? null,
+            limitTokens: $headers['x-ratelimit-limit-tokens'][0] ?? null,
+            remainingRequests: $headers['x-ratelimit-remaining-requests'][0] ?? null,
+            remainingTokens: $headers['x-ratelimit-remaining-tokens'][0] ?? null,
+            resetRequests: $headers['x-ratelimit-reset-requests'][0] ?? null,
+            resetTokens: $headers['x-ratelimit-reset-tokens'][0] ?? null,
         );
     }
 

--- a/src/Capabilities/Embeddings/Responses/EmbeddingsResponse.php
+++ b/src/Capabilities/Embeddings/Responses/EmbeddingsResponse.php
@@ -32,12 +32,12 @@ class EmbeddingsResponse
             totalTokens: $data['usage']['total_tokens'],
         );
         $this->rateLimit = new RateLimit(
-            limitRequests: $headers['x-ratelimit-limit-requests'][0],
-            limitTokens: $headers['x-ratelimit-limit-tokens'][0],
-            remainingRequests: $headers['x-ratelimit-remaining-requests'][0],
-            remainingTokens: $headers['x-ratelimit-remaining-tokens'][0],
-            resetRequests: $headers['x-ratelimit-reset-requests'][0],
-            resetTokens: $headers['x-ratelimit-reset-tokens'][0],
+            limitRequests: $headers['x-ratelimit-limit-requests'][0] ?? null,
+            limitTokens: $headers['x-ratelimit-limit-tokens'][0] ?? null,
+            remainingRequests: $headers['x-ratelimit-remaining-requests'][0] ?? null,
+            remainingTokens: $headers['x-ratelimit-remaining-tokens'][0] ?? null,
+            resetRequests: $headers['x-ratelimit-reset-requests'][0] ?? null,
+            resetTokens: $headers['x-ratelimit-reset-tokens'][0] ?? null,
         );
         $this->embedding = new Embedding($data['data'][0]);
     }

--- a/src/Capabilities/Responses/RateLimit.php
+++ b/src/Capabilities/Responses/RateLimit.php
@@ -5,12 +5,12 @@ namespace Outl1ne\NovaOpenAI\Capabilities\Responses;
 class RateLimit
 {
     public function __construct(
-        public readonly int $limitRequests,
-        public readonly int $limitTokens,
-        public readonly int $remainingRequests,
-        public readonly int $remainingTokens,
-        public readonly string $resetRequests,
-        public readonly string $resetTokens,
+        public readonly int|null $limitRequests,
+        public readonly int|null $limitTokens,
+        public readonly int|null $remainingRequests,
+        public readonly int|null $remainingTokens,
+        public readonly string|null $resetRequests,
+        public readonly string|null $resetTokens,
     ) {
     }
 }


### PR DESCRIPTION
Sometimes the rate limit headers are missing, this fixes errors in those cases.

`Undefined array key "x-ratelimit-limit-tokens"`