### PR TITLE
refactor: Update return type of calculateCost method to float

### DIFF
--- a/src/Capabilities/CapabilityClient.php
+++ b/src/Capabilities/CapabilityClient.php
@@ -74,7 +74,7 @@ abstract class CapabilityClient
         throw $e;
     }
 
-    protected function calculateCost($response): ?int
+    protected function calculateCost($response): ?float
     {
         if ($response->model === null || $response->usage === null) {
             return null;


### PR DESCRIPTION
The calculateCost method now returns a float instead of an int for improved
accuracy when calculating costs based on response data.