### PR TITLE
feat: Add capability storing callback

### DIFF
--- a/src/Capabilities/Capability.php
+++ b/src/Capabilities/Capability.php
@@ -10,6 +10,7 @@ class Capability
     public Closure $shouldStorePendingCallback;
     public Closure $shouldStoreCallback;
     public Closure $shouldStoreErrorsCallback;
+    public Closure $storingCallback;
 
     public function __construct(
         public readonly OpenAI $openAI,
@@ -17,6 +18,7 @@ class Capability
         $this->shouldStorePending(fn () => true);
         $this->shouldStore(fn () => true);
         $this->shouldStoreErrors(fn () => true);
+        $this->storing(fn ($model) => $model);
     }
 
     public function shouldStorePending(Closure $callback): self
@@ -34,6 +36,12 @@ class Capability
     public function shouldStoreErrors(Closure $callback): self
     {
         $this->shouldStoreErrorsCallback = $callback;
+        return $this;
+    }
+
+    public function storing(Closure $callback): self
+    {
+        $this->storingCallback = $callback;
         return $this;
     }
 }

--- a/src/Capabilities/CapabilityClient.php
+++ b/src/Capabilities/CapabilityClient.php
@@ -39,6 +39,8 @@ abstract class CapabilityClient
 
     public function store($response = null)
     {
+        $this->request = ($this->capability->storingCallback)($this->request);
+
         if (($this->capability->shouldStoreCallback)($response)) {
             $this->request->save();
         }


### PR DESCRIPTION
Added a new storing callback to the Capability class to modify the request
before saving. The callback is executed in the CapabilityClient store method
before checking if the response should be stored.