### PR TITLE
refactor: Update text-embedding model name to improve clarity and consistency

### DIFF
--- a/resources/openai-pricing.json
+++ b/resources/openai-pricing.json
@@ -73,7 +73,7 @@
   "embedding": {
     "text-embedding-3-small": 0.00002,
     "text-embedding-3-large": 0.00013,
-    "ada-v2": 0.0001
+    "text-embedding-ada-002": 0.0001
   },
   "base-models": {
     "davinci-002": 0.002,


### PR DESCRIPTION
Changed the model name from "ada-v2" to "text-embedding-ada-002" for better
understanding and consistency in the openai-pricing.json file.