### PR TITLE
fix badge not having files method type

### DIFF
--- a/src/Nova/OpenAIRequest.php
+++ b/src/Nova/OpenAIRequest.php
@@ -81,6 +81,7 @@ class OpenAIRequest extends Resource
                     OpenAIRequestMethod::AUDIO->value => 'bg-fuchsia-600 text-fuchsia-200',
                     OpenAIRequestMethod::THREADS->value => 'bg-neutral-600 text-neutral-200',
                     OpenAIRequestMethod::ASSISTANTS->value => 'bg-teal-600 text-teal-200',
+                    OpenAIRequestMethod::FILES->value => 'bg-gray-600 text-gray-200',
                 ])->sortable(),
             Number::make('Cost', 'cost')->sortable()->displayUsing(fn ($value) => $value === null ? null : '$' . number_format($value, 4)),
             Text::make('Request time', 'time_sec')->sortable()->displayUsing(fn () => "{$this->time_sec} sec"),


### PR DESCRIPTION
Fix error for: 
- Error trying to find type [files] inside of the field's type mapping.