### PR TITLE
feat: Add request timeout configuration

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -27,6 +27,11 @@ class Factory
     protected array $headers = [];
 
     /**
+     * The timeout for the outgoing requests
+     */
+    protected int $timeout = 30;
+
+    /**
      * The pricing configuration to calculate the cost of requests.
      */
     protected ?object $pricing = null;
@@ -87,6 +92,13 @@ class Factory
         return $this;
     }
 
+    public function withTimeout(int $timeout): self
+    {
+        $this->timeout = $timeout;
+
+        return $this;
+    }
+
     /**
      * Adds a pricing configuration.
      */
@@ -114,6 +126,6 @@ class Factory
 
         $baseUrl = rtrim($this->baseUrl ?: 'https://api.openai.com/v1', '/') . '/';
 
-        return new OpenAI($baseUrl, $headers, $this->pricing);
+        return new OpenAI($baseUrl, $headers, $this->timeout, $this->pricing);
     }
 }

--- a/src/NovaOpenAIServiceProvider.php
+++ b/src/NovaOpenAIServiceProvider.php
@@ -77,6 +77,7 @@ class NovaOpenAIServiceProvider extends ServiceProvider
             $apiKey = config('nova-openai.api_key');
             $organization = config('nova-openai.organization');
             $headers = config('nova-openai.headers');
+            $timeout = config('nova-openai.request_timeout');
             $pricingPath = config('nova-openai.pricing') ?? __DIR__ . '/../resources/openai-pricing.json';
             $pricing = json_decode(file_get_contents($pricingPath));
 
@@ -92,6 +93,7 @@ class NovaOpenAIServiceProvider extends ServiceProvider
                 ->withApiKey($apiKey)
                 ->withOrganization($organization)
                 ->withHttpHeaders($headers)
+                ->withTimeout($timeout)
                 ->withPricing($pricing)
                 ->make();
         });

--- a/src/OpenAI.php
+++ b/src/OpenAI.php
@@ -20,6 +20,7 @@ class OpenAI
     public function __construct(
         protected readonly string $baseUrl,
         protected readonly array $headers,
+        protected int $timeout,
         ?object $pricing = null,
     ) {
         $this->pricing = new Pricing($pricing);
@@ -53,6 +54,6 @@ class OpenAI
 
     public function http(): PendingRequest
     {
-        return clone Http::baseUrl($this->baseUrl)->withHeaders($this->headers);
+        return clone Http::baseUrl($this->baseUrl)->timeout($this->timeout)->withHeaders($this->headers);
     }
 }


### PR DESCRIPTION
Added the ability to set a request timeout for outgoing requests in the
OpenAI service provider and factory classes. This allows users to control
how long they want to wait for a response from the API.